### PR TITLE
Fortran: Removing in-line comments from previous additions

### DIFF
--- a/fortran/index.rst
+++ b/fortran/index.rst
@@ -22,9 +22,6 @@ Guidelines and recommendations
   Nevertheless targeted explanations of particular segments of interest are desirable.
   Each source file should have a homogeneous coding style.
 
->>PM: suggestion: remove all history comments at the beginning of each routine; these can
-be obtained from git history.<<
-
 * Contours of a routine or module should be considered with care, avoiding excessive length
   or complexity.
 
@@ -32,17 +29,12 @@ be obtained from git history.<<
   contouring. Interfaces that are not internal to a component should privilege as much as 
   possible native fortran datatypes rather than derived types.
 
->>PM: this does not make sense; most modern libraries (eg Atlas) use derived types.<<
-
 * Naming of new variables, routines and modules should help the reader understand code as efficiently 
   as possible. *Renaming of legacy / existing code?*
 
 * Large arrays should be declared as allocatable, to avoid excessive stack usage. 
   Small arrays, and in particular those declared in tight code (this should be avoided wherever 
   possible!) should be automatic, to benefit from faster stack handling.
-
->>PM: definition of large and small arrays ? I recommand banning ALLOCATABLEs in all NPROMA routines
-(ie those which process a single NPROMA block).<<
 
 * If an allocatable variable can be used rather than a pointer, opt for the allocatable for 
   safety reasons.
@@ -68,10 +60,6 @@ be obtained from git history.<<
 
 * If execution is to be aborted by the code, a call to ABOR1, with a meaningful message, 
   should be used.
- 
->>PM: I think we should also discuss how source files are organized in the git repository;
-in particular, having an arpifs/module directory with all the modules does not make 
-sense.<<
 
 
 Rules (as checked by norms checker)

--- a/fortran/rules/L3.rst
+++ b/fortran/rules/L3.rst
@@ -3,8 +3,6 @@ L3 : global variables
 
 Only parameters to be declared as global variables.
 
->>PM: Does this mean that global variables are forbidden ? I think it is a good idea, but there is a lot of work to do to get there.<<
-
 Example : 
 
 

--- a/fortran/rules/L5.rst
+++ b/fortran/rules/L5.rst
@@ -7,20 +7,9 @@ All arguments to routines shall be declared with an INTENT.
 * ``INTENT(OUT)`` : variables whose previous content is irrelevant, and which are written to in the scope
 * ``INTENT(INOUT)`` : all other variables
 
->>PM: Structures like YDVARS which contain some pointers can have the INTENT(IN) attribute, and
-have their pointed values modified. This is a problem, as we will have such structures everywhere
-in the code.
-Furthermore, using the ``INTENT(OUT)`` attribute for such variables may cause some compilers 
-(eg NAG) to wipe their contents.
-And YDVARS also contains some metadata that should remain constant. I think we do not have any
-other choice but to declare YDVARS (and other similar structures) with ``INTENT(IN)`` everywhere.
-<<
-
 *warning*
 Particular care should be paid to intent of array variables:
 * arrays where only a few locations are updated but other locations 
 contain required values, *must* be declared as INTENT(INOUT)
-
->>PM: no compiler can make the difference between INTENT(INOUT) and INTENT(OUT).<<
 
 * arguments declared as allocatable may be deallocated at entry if declared as INTENT(OUT)

--- a/fortran/rules/SC4.rst
+++ b/fortran/rules/SC4.rst
@@ -6,6 +6,3 @@ horizontal array index shall not be used.
 
 The Loki tool relies on elements of code style in order to identify loops needing to be manipulated
 for architecture specialisation. 
-
->>PM: some parts of cucalln.F90 rely on indirect addressing, and can nevertheless transformed. I think
-this constraint should be relaxed.<<


### PR DESCRIPTION
The respective comments and suggestions are now logged as issues with the original comment quoted. This was agreed in offline communication.

The specific rules pertaining to the removed comments are #2 , #3 , #4 , #8 , #9 , #10 and #11 .