### PR TITLE
Static landing page and footer links

### DIFF
--- a/fortran/_templates/footer.html
+++ b/fortran/_templates/footer.html
@@ -1,0 +1,10 @@
+{%- extends '!footer.html' %}
+
+{% block extrafooter %}
+<p>
+    <a href="https://www.ecmwf.int/en/accessibility" title="Accessibility">Accessibility</a> -
+    <a href="https://www.ecmwf.int/en/privacy" title="Privacy">Privacy</a> -
+    <a href="https://www.ecmwf.int/en/terms-use" title="Terms of use">Terms of use</a> -
+    <a href="https://www.ecmwf.int/en/about/contact-us" title="Contact us">Contact us</a>
+</p>
+{% endblock %}

--- a/fortran/conf.py
+++ b/fortran/conf.py
@@ -20,7 +20,7 @@
 # -- Project information -----------------------------------------------------
 
 project = 'IFS Fortran standard'
-copyright = '2024-, ECMWF, Meteo-France'
+copyright = '2024-, ECMWF, Météo-France'
 author = 'ECMWF'
 
 # The short X.Y version
@@ -88,7 +88,8 @@ html_theme_options = {
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+# html_static_path = ['_static']
+html_static_path = []
 
 # Custom sidebar templates, must be a dictionary that maps document names
 # to template names.

--- a/index.html
+++ b/index.html
@@ -483,7 +483,7 @@
                 <p>Follow the links below for each standard and note their applicability:</p>
                 <ol>
                     <li><a href="/docs/ifs-arpege-coding-standards/fortran">Fortran</a> - applicable to both IFS and Arpège</li>
-                    <li><a href="/docs/ifs-arpege-coding-standards/python">Python</a> - applicable to IFS only</li>
+                    <!-- <li><a href="/docs/ifs-arpege-coding-standards/python">Python</a> - applicable to IFS only</li> -->
                     <li><a href="/docs/ifs-arpege-coding-standards/shell">Shell</a> - applicable to IFS only</li>
                 </ol>
             </div>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,502 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="shortcut icon" type="image/x-icon"
+        href="data:image/x-icon;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAAJ1JREFUeNpiYBjygBHOiphYDyQLgFgAKvIAygeBCUCsAGV/APNX5DciDIiYeB5IGpBo+QWgIYbMUJsjoIIbgDgDiBdAXaKBR1yCQccTyQvYQMTE9WB6RX4gFvEAkHcYgZz/KJIr8hlJ8QcT9WKBAi+AArEBKbAmQNkFUEX4xBsojkYmqBMNoa74gKTgAdSmACibASkhNUD1DAcAEGAAyz0yJNpSDRQAAAAASUVORK5CYII=">
+    <style type="text/css">
+        .space {
+            margin-left: 15px;
+        }
+    </style>
+    <title>ECMWF | IFS/Arpège coding standard</title>
+    <style type="text/css">
+        html,
+        body {
+            height: 100%;
+            width: 100%;
+            margin: 0;
+            padding: 0
+        }
+
+        @media (min-width: 960px) {
+            .ecmwf-template__title {
+                display: inline
+            }
+        }
+
+        .ecmwf-template__content-wrapper {
+            font-family: "Open Sans", "Helvetica Neue", Helvetica, Arial, sans-serif;
+            padding: 0 1em;
+            margin: 0 auto;
+            display: flex;
+            align-items: center;
+            height: 100%;
+            width: 100%
+        }
+
+        .ecmwf-template__header,
+        .ecmwf-template__footer {
+            font-family: "Open Sans", "Helvetica Neue", Helvetica, Arial, sans-serif;
+            background: #000;
+            color: #fff;
+            display: flex;
+            justify-content: flex-start;
+            align-items: center
+        }
+
+        .ecmwf-template__header *,
+        .ecmwf-template__footer * {
+            box-sizing: border-box
+        }
+
+        .ecmwf-template__header a,
+        .ecmwf-template__footer a {
+            color: #fff;
+            text-decoration: none;
+            display: flex;
+            align-items: center
+        }
+
+        .ecmwf-template__header a:hover,
+        .ecmwf-template__footer a:hover {
+            text-decoration: underline
+        }
+
+        .ecmwf-template__header a:hover,
+        .ecmwf-template__header a:focus,
+        .ecmwf-template__header a:active,
+        .ecmwf-template__footer a:hover,
+        .ecmwf-template__footer a:focus,
+        .ecmwf-template__footer a:active {
+            color: #fff
+        }
+
+        .ecmwf-template__header a .ecmwf-template__icon,
+        .ecmwf-template__footer a .ecmwf-template__icon {
+            width: 1em;
+            height: 1em;
+            fill: currentColor
+        }
+
+        .ecmwf-template__header .ecmwf-template__links,
+        .ecmwf-template__footer .ecmwf-template__links {
+            display: flex;
+            margin-left: auto;
+            height: 100%
+        }
+
+        .ecmwf-template__header .ecmwf-template__links>a,
+        .ecmwf-template__footer .ecmwf-template__links>a {
+            padding: 0 1em
+        }
+
+        .ecmwf-template__header .ecmwf-template__links,
+        .ecmwf-template__footer .ecmwf-template__links {
+            min-width: 14em;
+            /* background: #fff; */
+            color: #000;
+            left: auto;
+            right: 0;
+            box-shadow: 0 3px 6px rgba(0, 0, 0, 0.15)
+        }
+
+        .ecmwf-template__header .ecmwf-template__links ,
+        .ecmwf-template__footer .ecmwf-template__links  {
+            padding: 1em 1.5em;
+            border-bottom: 1px solid #000;
+            color: currentColor;
+            font-size: 1.5em;
+            justify-content: center
+        }
+
+        @media (min-width: 960px) {
+
+            .ecmwf-template__header .ecmwf-template__links .ecmwf-template__dropdown-content a,
+            .ecmwf-template__footer .ecmwf-template__links .ecmwf-template__dropdown-content a {
+                border: none;
+                font-size: 1em;
+                justify-content: flex-start
+            }
+        }
+
+        @media (min-width: 960px) {
+
+            .ecmwf-template__header a .ecmwf-template__icon,
+            .ecmwf-template__footer a .ecmwf-template__icon {
+                margin-right: 0.6em
+            }
+        }
+
+        .ecmwf-template__header {
+            font-size: 14px;
+            height: 60px
+        }
+
+        .ecmwf-template__header .ecmwf-template__menu {
+            height: 100%;
+            display: flex;
+            margin-right: 1em
+        }
+
+        .ecmwf-template__header .ecmwf-template__menu .ecmwf-template__icon {
+            font-size: 2em;
+            margin-right: 0
+        }
+
+        .ecmwf-template__header .ecmwf-template__menu .ecmwf-template__header-menu {
+            border-top: 1px solid #fff;
+            background: #000;
+            font-size: 20px;
+            width: 100vw;
+            height: calc(100vh - 60px);
+            display: flex;
+            flex-direction: column;
+            overflow-y: auto
+        }
+
+        .ecmwf-template__header .ecmwf-template__menu .ecmwf-template__header-menu>a {
+            border-color: #fff;
+            border-width: 0 0 1px 0;
+            border-style: solid;
+            text-decoration: none;
+            color: #fff;
+            padding: 1em 1.5em;
+            display: flex;
+            align-items: center
+        }
+
+        .ecmwf-template__header .ecmwf-template__menu .ecmwf-template__header-menu>a:hover,
+        .ecmwf-template__header .ecmwf-template__menu .ecmwf-template__header-menu>a.ecmwf-template__active {
+            border-color: #fff
+        }
+
+        @media (min-width: 960px) {
+            .ecmwf-template__header .ecmwf-template__menu .ecmwf-template__header-menu {
+                height: 3.1em;
+                justify-content: center;
+                flex-direction: row
+            }
+
+            .ecmwf-template__header .ecmwf-template__menu .ecmwf-template__header-menu>a {
+                border-color: transparent;
+                border-width: 2px 0 3px 0;
+                padding: 0 1.5em
+            }
+        }
+
+        .ecmwf-template__header .ecmwf-template__branding {
+            margin: 0;
+            font-weight: 400;
+            font-size: 2em;
+            display: flex;
+            align-items: center;
+            flex-grow: 1;
+            justify-content: center
+        }
+
+        .ecmwf-template__header .ecmwf-template__branding .ecmwf-template__logo {
+            font-size: 0.8em
+        }
+
+        .ecmwf-template__header .ecmwf-template__branding .ecmwf-template__logo .ecmwf-template__icon {
+            width: 5.9em;
+            margin-right: 0
+        }
+
+        .ecmwf-template__header .ecmwf-template__branding .ecmwf-template__logo+.ecmwf-template__title {
+            display: none;
+            margin-left: 1em;
+            padding-left: 1em;
+            border-left: 1px solid #fff;
+            font-size: 0.5em
+        }
+
+        .ecmwf-template__header .ecmwf-template__links {
+            margin-left: 1em
+        }
+
+        .ecmwf-template__header .ecmwf-template__help-menu {
+            display: none
+        }
+
+        .ecmwf-template__header .ecmwf-template__user-info {
+            display: none
+        }
+
+        .ecmwf-template__header .ecmwf-template__user-info .ecmwf-template__icon {
+            width: 1.5em;
+            height: 1.5em;
+            padding: 0 0.25em
+        }
+
+        .ecmwf-template__header .ecmwf-template__log-in {
+            display: none
+        }
+
+        .ecmwf-template__header .ecmwf-template__log-in .ecmwf-template__icon {
+            width: 1.5em;
+            height: 1.5em;
+            padding: 0 0.25em
+        }
+
+        .ecmwf-template__header .ecmwf-template__log-in .ecmwf-template__title {
+            display: none
+        }
+
+        @media (min-width: 720px) {
+            .ecmwf-template__header .ecmwf-template__branding .ecmwf-template__logo+.ecmwf-template__title {
+                display: inline-block;
+                font-size: 0.6em
+            }
+        }
+
+        @media (min-width: 960px) {
+            .ecmwf-template__header {
+                height: 48px
+            }
+
+            .ecmwf-template__header .ecmwf-template__branding {
+                justify-content: flex-start
+            }
+
+            .ecmwf-template__header .ecmwf-template__help-menu {
+                display: block
+            }
+
+            .ecmwf-template__header .ecmwf-template__user-info .ecmwf-template__icon {
+                width: 1em;
+                height: 1em;
+                padding: 0
+            }
+
+            .ecmwf-template__header .ecmwf-template__log-in .ecmwf-template__icon {
+                width: 1em;
+                height: 1em;
+                padding: 0
+            }
+
+            .ecmwf-template__header .ecmwf-template__log-in .ecmwf-template__title {
+                display: inline-block
+            }
+        }
+
+        .ecmwf-template__subheader {
+            font-family: "Open Sans", "Helvetica Neue", Helvetica, Arial, sans-serif;
+            background: #000;
+            color: #fff;
+            display: flex;
+            padding: 0.5em 1em;
+            border-top: 1px solid currentColor;
+            font-size: 0.9em
+        }
+
+        .ecmwf-template__subheader .ecmwf-template__app-title {
+            display: flex;
+            flex-grow: 1;
+            justify-content: center;
+            align-items: center
+        }
+
+        @media (min-width: 720px) {
+            .ecmwf-template__subheader {
+                display: none
+            }
+        }
+
+        .ecmwf-template__content {
+            flex-direction: column;
+            display: flex;
+            min-height: calc(100vh - 60px)
+        }
+
+        .ecmwf-template__content .ecmwf-template__content-wrapper {
+            flex-grow: 1;
+            align-items: flex-start
+        }
+
+        @media (min-width: 960px) {
+            .ecmwf-template__content {
+                min-height: calc(100vh - 48px - 50px)
+            }
+        }
+
+        .ecmwf-template__footer {
+            font-size: 12.6px
+        }
+
+        .ecmwf-template__footer .ecmwf-template__content-wrapper {
+            display: flex;
+            flex-direction: column;
+            justify-content: space-between;
+            text-align: center
+        }
+
+        .ecmwf-template__footer .ecmwf-template__links {
+            width: 100%;
+            flex-direction: column;
+            order: 1
+        }
+
+        .ecmwf-template__footer .ecmwf-template__links a {
+            width: 100%;
+            justify-content: center;
+            padding: 1.5em 2em;
+            border-bottom: 1px solid #fff
+        }
+
+        .ecmwf-template__footer .ecmwf-template__copyright {
+            color: #999;
+            display: block;
+            width: 100%;
+            margin: 2em 0;
+            order: 2
+        }
+
+        @media (min-width: 960px) {
+            .ecmwf-template__footer {
+                height: 50px
+            }
+
+            .ecmwf-template__footer .ecmwf-template__content-wrapper {
+                flex-direction: row;
+                text-align: left
+            }
+
+            .ecmwf-template__footer .ecmwf-template__links {
+                margin-left: auto;
+                flex-direction: row;
+                justify-content: flex-end;
+                order: 2
+            }
+
+            .ecmwf-template__footer .ecmwf-template__links a {
+                width: auto;
+                border: none;
+                padding: 0 1em;
+                flex-shrink: 0
+            }
+
+            .ecmwf-template__footer .ecmwf-template__copyright {
+                padding-left: 1em;
+                margin: 0;
+                order: 1
+            }
+        }
+
+        @media (min-width: 1400px) {
+            body.ecmwf-template__contained .ecmwf-template__content-wrapper {
+                width: 1400px
+            }
+        }
+
+        body.ecmwf-template__contained .ecmwf-template__header .ecmwf-template__menu .ecmwf-template__header-menu {
+            left: 0
+        }
+
+        @media (min-width: 1400px) {
+            body.ecmwf-template__contained .ecmwf-template__header .ecmwf-template__menu .ecmwf-template__header-menu {
+                left: calc(-1 * (100vw - 1400px) / 2)
+            }
+        }
+    </style>
+</head>
+
+<body class="ecmwf-template__fluid">
+    <header class="ecmwf-template__header">
+        <div class="ecmwf-template__content-wrapper">
+            <h1 class="ecmwf-template__branding"><a class="ecmwf-template__logo" href="https://www.ecmwf.int"
+                    tabIndex="1"><svg class="ecmwf-template__icon" xmlns="http://www.w3.org/2000/svg"
+                        viewBox="0 0 480.5 82.68">
+                        <title>ECMWF logo</title>
+                        <path d="M183.28,6.8V19.74H146.34v15h33.91v12H146.34V63.84h37.73V76.78H130.95V6.8h52.33Z">
+                        </path>
+                        <path
+                            d="M234.33,25.47a15.49,15.49,0,0,0-3.43-3.87,16.06,16.06,0,0,0-10.09-3.53,18,18,0,0,0-8.82,2,16.65,16.65,0,0,0-5.88,5.39,23.6,23.6,0,0,0-3.28,7.69,38.33,38.33,0,0,0-1,8.92,35.64,35.64,0,0,0,1,8.58,23.13,23.13,0,0,0,3.28,7.5A16.8,16.8,0,0,0,212,63.5a18,18,0,0,0,8.82,2q7.06,0,11-4.31a19.94,19.94,0,0,0,4.85-11.37h14.9a35.6,35.6,0,0,1-3,11.86,28.43,28.43,0,0,1-6.47,9,27.5,27.5,0,0,1-9.41,5.68,34.5,34.5,0,0,1-11.86,2,35.88,35.88,0,0,1-14.46-2.79,31,31,0,0,1-10.83-7.69,34.06,34.06,0,0,1-6.76-11.51,42.25,42.25,0,0,1-2.35-14.26,43.72,43.72,0,0,1,2.35-14.55,35,35,0,0,1,6.76-11.71A30.92,30.92,0,0,1,206.35,8,37.52,37.52,0,0,1,231.73,6.8a29.63,29.63,0,0,1,9.21,4.85,26.23,26.23,0,0,1,6.71,7.89A28.2,28.2,0,0,1,251,30.32h-14.9A12.58,12.58,0,0,0,234.33,25.47Z">
+                        </path>
+                        <path
+                            d="M279.37,6.8l16.37,48.12h0.2L311.42,6.8h21.66v70H318.67V27.19h-0.2L301.32,76.78H289.46l-17.15-49.1h-0.2v49.1H257.71V6.8h21.66Z">
+                        </path>
+                        <path
+                            d="M394,76.78L382.19,29.15H382L370.33,76.78H354.75l-18.52-70h15.39l11.07,47.63h0.2L375,6.8h14.41L401.4,55h0.2L413.06,6.8h15.09l-18.82,70H394Z">
+                        </path>
+                        <path d="M480.5,6.8V19.74H446.69V35.91H476v12h-29.3V76.78H431.31V6.8h49.2Z"></path>
+                        <path d="M0.4,46H34.81V36.68H0.4A27.1,27.1,0,0,0,.4,46Z"></path>
+                        <path
+                            d="M115,49.24a41,41,0,0,1-40,33.44A44,44,0,0,1,58.1,79a40.9,40.9,0,0,1-17.36,3.64A40.67,40.67,0,0,1,.76,49.4l25.09,0A17.47,17.47,0,0,0,41.77,59.64,18,18,0,0,0,58.36,47.81,17.68,17.68,0,0,0,91.12,49.3Z">
+                        </path>
+                        <path
+                            d="M115,33.44A41,41,0,0,0,74.94,0,43.08,43.08,0,0,0,58.1,3.69,40.19,40.19,0,0,0,40.74,0a40.66,40.66,0,0,0-40,33.28l25.09,0A17.46,17.46,0,0,1,41.77,23,18,18,0,0,1,58.36,34.86a17.69,17.69,0,0,1,32.77-1.48Z">
+                        </path>
+                    </svg></a><span class="ecmwf-template__title">Official IFS-Arpège coding standards</span>
+            </h1>
+                </div>
+            </nav>
+        </div>
+    </header>
+    <header class="ecmwf-template__subheader">
+        <div class="ecmwf-template__app-title">Official coding standard for IFS / Arpège</div>
+    </header>
+    <style>
+        .ecmwf-template__header a {
+            border-bottom-width: 0;
+        }
+
+        #run,
+        #chart {
+            padding: 3px;
+            margin-top: 7px;
+            /*margin-right: 1em;*/
+        }
+
+        #main-menu label {
+            color: rgb(231, 231, 231);
+            font-size: 14px;
+        }
+
+        #main-menu img {
+            margin-bottom: -8px;
+        }
+
+        #main-menu .app-menu-space {
+            width: 2em;
+        }
+
+        #next,
+        #previous {
+            cursor: pointer;
+        }
+
+        .space {
+            width: 100%;
+            /*needed now there's no table*/
+        }
+    </style>
+
+    <main class="ecmwf-template__content">
+        <div class="ecmwf-template__content-wrapper">
+            <div>
+                <p>These websites contain the HTML rendering of the shared IFS-Arpège coding standards jointly developed by ECMWF and Météo-France.</p>
+                <p>The content is auto-generated and deployed from the corresponding <a href="https://github.com/ecmwf-ifs/ifs-arpege-coding-standards">Github repository</a>.</p>
+                <p>Follow the links below for each standard and note their applicability:</p>
+                <ol>
+                    <li><a href="/docs/ifs-arpege-coding-standards/fortran">Fortran</a> - applicable to both IFS and Arpège</li>
+                    <li><a href="/docs/ifs-arpege-coding-standards/python">Python</a> - applicable to IFS only</li>
+                    <li><a href="/docs/ifs-arpege-coding-standards/shell">Shell</a> - applicable to IFS only</li>
+                </ol>
+            </div>
+        </div>
+    </main>
+    <footer class="ecmwf-template__footer">
+        <div class="ecmwf-template__content-wrapper">
+            <div class="ecmwf-template__copyright">&copy; European Centre for Medium-Range Weather Forecasts</div>
+            <nav class="ecmwf-template__links"><a href="https://www.ecmwf.int/en/accessibility"
+                    title="Accessibility">Accessibility</a><a href="https://www.ecmwf.int/en/privacy"
+                    title="Privacy">Privacy</a><a href="https://www.ecmwf.int/en/terms-use" title="Terms of use">Terms
+                    of use</a><a href="https://www.ecmwf.int/en/about/contact-us" title="Contact us">Contact us</a>
+            </nav>
+        </div>
+    </footer>
+</body>

--- a/python/_templates/footer.html
+++ b/python/_templates/footer.html
@@ -1,0 +1,10 @@
+{%- extends '!footer.html' %}
+
+{% block extrafooter %}
+<p>
+    <a href="https://www.ecmwf.int/en/accessibility" title="Accessibility">Accessibility</a> -
+    <a href="https://www.ecmwf.int/en/privacy" title="Privacy">Privacy</a> -
+    <a href="https://www.ecmwf.int/en/terms-use" title="Terms of use">Terms of use</a> -
+    <a href="https://www.ecmwf.int/en/about/contact-us" title="Contact us">Contact us</a>
+</p>
+{% endblock %}

--- a/python/conf.py
+++ b/python/conf.py
@@ -88,7 +88,8 @@ html_theme_options = {
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+# html_static_path = ['_static']
+html_static_path = []
 
 # Custom sidebar templates, must be a dictionary that maps document names
 # to template names.

--- a/shell/_templates/footer.html
+++ b/shell/_templates/footer.html
@@ -1,0 +1,10 @@
+{%- extends '!footer.html' %}
+
+{% block extrafooter %}
+<p>
+    <a href="https://www.ecmwf.int/en/accessibility" title="Accessibility">Accessibility</a> -
+    <a href="https://www.ecmwf.int/en/privacy" title="Privacy">Privacy</a> -
+    <a href="https://www.ecmwf.int/en/terms-use" title="Terms of use">Terms of use</a> -
+    <a href="https://www.ecmwf.int/en/about/contact-us" title="Contact us">Contact us</a>
+</p>
+{% endblock %}

--- a/shell/conf.py
+++ b/shell/conf.py
@@ -20,7 +20,7 @@
 # -- Project information -----------------------------------------------------
 
 project = 'IFS_shell_guidelines'
-copyright = '2023, ECMWF'
+copyright = '2023-, ECMWF'
 author = 'ECMWF'
 
 # The short X.Y version
@@ -88,7 +88,8 @@ html_theme_options = {
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+# html_static_path = ['_static']
+html_static_path = []
 
 # Custom sidebar templates, must be a dictionary that maps document names
 # to template names.


### PR DESCRIPTION
This incorporates the changes requested by WebMOG to make the HTML websites publicly available.

It adds the static landing page that I have added to the Site root and which is currently displayed when visiting the non-language specific base url https://sites.ecmwf.int/docs/ifs-arpege-coding-standards . I figured it's useful to track this file as part of the repository even though an automatic deployment mechanism is likely unnecessary considering it's not intended to change.
I've used one of the web apps as a template, stripped java script & anything that looked unnecessary and filled-in the content. Please suggest changes to the appearance or content if required, and I will update the PR as well as the deployed version.

Furthermore, this PR adds links to terms of use, privacy statement and contact page that are placed in the footer of the generated Sphinx documentation.

Lastly, I removed the `_static` entry from the config files as this generated a build warning due to it's non-existence.