### PR TITLE
Fix sphinx-action version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
             - uses: actions/checkout@v4
 
             - name: Build Sphinx documentation
-              uses: ammaraskar/sphinx-action@master
+              uses: ammaraskar/sphinx-action@8.1.3
               with:
                   docs-folder: "${{ matrix.language }}/"
                   pre-build-command: "pip install -r requirements.txt"


### PR DESCRIPTION
Deployed site does not look right, one error as a possible cause is use of an old version of Sphinx (2.4.4) due to choice of master tag of https://github.com/ammaraskar/sphinx-action.